### PR TITLE
Fix IO 32-bit limit, adjust JNB accordingly, JNB improvements

### DIFF
--- a/application/generate_procs.tcl
+++ b/application/generate_procs.tcl
@@ -223,5 +223,5 @@ proc add_slice_ip {name dIn_width dIn_from dIn_downto dout_width} {
 	startgroup
 	create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice:1.0 $name	
 	endgroup
-	set_property -dict [list CONFIG.DIN_FROM $dIn_from CONFIG.DIN_WIDTH $dInWidth CONFIG.DIN_TO $dIn_downto CONFIG.DOUT_WIDTH $dout_width] [get_bd_cells $name]
+	set_property -dict [list CONFIG.DIN_FROM $dIn_from CONFIG.DIN_WIDTH $dIn_width CONFIG.DIN_TO $dIn_downto CONFIG.DOUT_WIDTH $dout_width] [get_bd_cells $name]
 }

--- a/application/generate_procs.tcl
+++ b/application/generate_procs.tcl
@@ -211,3 +211,10 @@ proc make_external_connection {component bd_pin external_pin_name} {
 	set ext_connector $bd_pin\_0
 	set_property name $external_pin_name [get_bd_ports $ext_connector]
 }
+
+proc add_concat_ip {num_ports name} {
+	startgroup
+	create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 $name
+	endgroup
+	set_property -dict [list CONFIG.NUM_PORTS {$num_ports}] [get_bd_cells $name]
+}

--- a/application/generate_procs.tcl
+++ b/application/generate_procs.tcl
@@ -212,9 +212,16 @@ proc make_external_connection {component bd_pin external_pin_name} {
 	set_property name $external_pin_name [get_bd_ports $ext_connector]
 }
 
-proc add_concat_ip {num_ports name} {
+proc add_concat_ip {name num_ports} {
 	startgroup
 	create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 $name
 	endgroup
 	set_property -dict [list CONFIG.NUM_PORTS {$num_ports}] [get_bd_cells $name]
+}
+
+proc add_slice_ip {name dIn_width dIn_from dIn_downto dout_width} {
+	startgroup
+	create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice:1.0 $name	
+	endgroup
+	set_property -dict [list CONFIG.DIN_FROM {$dIn_from} CONFIG.DIN_WIDTH {$dInWidth} CONFIG.DIN_TO {$dIn_downto} CONFIG.DOUT_WIDTH {$dout_width}] [get_bd_cells $name]
 }

--- a/application/generate_procs.tcl
+++ b/application/generate_procs.tcl
@@ -216,12 +216,12 @@ proc add_concat_ip {name num_ports} {
 	startgroup
 	create_bd_cell -type ip -vlnv xilinx.com:ip:xlconcat:2.1 $name
 	endgroup
-	set_property -dict [list CONFIG.NUM_PORTS {$num_ports}] [get_bd_cells $name]
+	set_property -dict [list CONFIG.NUM_PORTS $num_ports] [get_bd_cells $name]
 }
 
 proc add_slice_ip {name dIn_width dIn_from dIn_downto dout_width} {
 	startgroup
 	create_bd_cell -type ip -vlnv xilinx.com:ip:xlslice:1.0 $name	
 	endgroup
-	set_property -dict [list CONFIG.DIN_FROM {$dIn_from} CONFIG.DIN_WIDTH {$dInWidth} CONFIG.DIN_TO {$dIn_downto} CONFIG.DOUT_WIDTH {$dout_width}] [get_bd_cells $name]
+	set_property -dict [list CONFIG.DIN_FROM $dIn_from CONFIG.DIN_WIDTH $dInWidth CONFIG.DIN_TO $dIn_downto CONFIG.DOUT_WIDTH $dout_width] [get_bd_cells $name]
 }

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -345,16 +345,16 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
         read_signals_string = ""
         
         for sig in small_output_signals:
-            read_signals_string += "\n\t\t" + sig + "_val = " + sub_signals[i] + ".read(0)"    # reading each (small <32 bit) signal
+            read_signals_string += "\n\t\t" + sig + "_val = " + sig + ".read(0)"    # reading each (small <32 bit) signal
         
         for sig_array in large_output_signals:
             top_level_signal = sig_array[0]
             for sig in sig_array[1:]:
-                read_signals_string += "\n\t\t" + sig + "_val = " + sub_signals[i] + ".read(0)"    # reading each (small <32 bit) signal
+                read_signals_string += "\n\t\t" + sig + "_val = " + sig + ".read(0)"    # reading each (small <32 bit) signal
             read_signals_string += "\n\t\t" + top_level_signal + "_val =" 
             read_sigs_substring = ""
             for x in range(1, len(sig_array)): # 1 as first element is top_level name
-                read_sigs_substring = f" | ({sig_array[x]}_val << {32*x})" + read_sigs_substring
+                read_sigs_substring = f" | ({sig_array[x]}_val << {32*x-1})" + read_sigs_substring
             read_signals_string += read_sigs_substring[2:]
 
         # for i in range(len(sub_signals)):

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -197,18 +197,23 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
             input_split = [gpio_name]
             while gpio_width - pin_counter > 0:
                 if gpio_width - pin_counter  > 32:
-                    split_signals.append([f"{gpio_name}_{pin_counter}_{pin_counter+31}", 32])
+                    signal_name = f"{gpio_name}_{pin_counter+31}_{pin_counter}"
+                    signal_width = 32
+                    split_signals.append([signal_name, signal_width])
                     if gpio_mode == "out":
-                        output_split.append(f"{gpio_name}_{pin_counter}_{pin_counter+31}")
+                        output_split.append()
                     else:
-                        input_split.append(f"{gpio_name}_{pin_counter}_{pin_counter+31}")
+                        input_split.append()
                     pin_counter += 32
                 elif gpio_width - pin_counter <= 32:
-                    split_signals.append([f"{gpio_name}_{pin_counter}_{gpio_width-1}", gpio_width-pin_counter])
+                    # signal_name = gpioName_X_downto_Y -> gpio_name_X_Y
+                    signal_name = f"{gpio_name}_{gpio_width-1}_{pin_counter}"
+                    signal_width = gpio_width-pin_counter
+                    split_signals.append([signal_name, signal_width])
                     if gpio_mode == "out":
-                        output_split.append(f"{gpio_name}_{pin_counter}_{pin_counter+31}")
+                        output_split.append(signal_name)
                     else:
-                        input_split.append(f"{gpio_name}_{pin_counter}_{pin_counter+31}")
+                        input_split.append(signal_name)
                     pin_counter += gpio_width - pin_counter
                     
             if len(output_split) > 1:

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -201,9 +201,9 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
                     signal_width = 32
                     split_signals.append([signal_name, signal_width])
                     if gpio_mode == "out":
-                        output_split.append()
+                        output_split.append(signal_name)
                     else:
-                        input_split.append()
+                        input_split.append(signal_name)
                     pin_counter += 32
                 elif gpio_width - pin_counter <= 32:
                     # signal_name = gpioName_X_downto_Y -> gpio_name_X_Y

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -481,7 +481,31 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
             # print(test_converted_to_decimal_from_radix)
 
             # Create title cell.
-            markdown_cell = nbf.v4.new_markdown_cell(f"**Test Case: {test_number}**")
+            
+
+            # Testbench Plan Cell
+            markdown_cell_contents = f"**Test Case: {test_number}**\n\n"
+            # Row 1 Signals:
+            markdown_cell_contents += "| "
+            for s in signals_line:
+                markdown_cell_contents += s + " | "
+            markdown_cell_contents += "\n|"
+            for s in signals_line:
+                markdown_cell_contents += ":----:|"
+            # Row 2 Mode:
+            markdown_cell_contents += "\n| "
+            for m in mode_line:
+                markdown_cell_contents += m + " | "
+            # Row 3 Radix:
+            markdown_cell_contents += "\n| "
+            for r in radix_line:
+                markdown_cell_contents += r + " | "
+            # Row 4+ Test Cases:
+            markdown_cell_contents += "\n| "
+            for t in test_cases[test_number]:
+                markdown_cell_contents += t + " | "
+
+            markdown_cell = nbf.v4.new_markdown_cell(markdown_cell_contents)
             notebook.cells.append(markdown_cell)
 
             # Code Cell:

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -274,7 +274,7 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
         code_cell_contents += "\n\ndef save_and_print_test(test=None):"
         code_cell_contents += "\n\tif None:"
         code_cell_contents += "\n\t\tprint('No Test Number Provided')"
-        code_cell_contents += "\n\telif test >= 0 and test <= 11: # number of tests"
+        code_cell_contents += f"\n\telif test >= 0 and test <= {len(test_cases)-1}: # number of tests"
         code_cell_contents += string2
         code_cell_contents += string3
         

--- a/application/notebook_generator.py
+++ b/application/notebook_generator.py
@@ -354,7 +354,7 @@ def create_jnb(path_to_hdlgen_file, output_filename=None, generic=False):
             read_signals_string += "\n\t\t" + top_level_signal + "_val =" 
             read_sigs_substring = ""
             for x in range(1, len(sig_array)): # 1 as first element is top_level name
-                read_sigs_substring = f" | ({sig_array[x]}_val << {32*x-1})" + read_sigs_substring
+                read_sigs_substring = f" | ({sig_array[x]}_val << {32*(x-1)})" + read_sigs_substring
             read_signals_string += read_sigs_substring[2:]
 
         # for i in range(len(sub_signals)):

--- a/application/tcl_generator.py
+++ b/application/tcl_generator.py
@@ -641,13 +641,13 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 # Except we store X downto Y values as well.
                 split_signal_dict = []
                 pin_counter = 0
-                while gpio_width_int - pin_counter >= 0:
+                while gpio_width_int - pin_counter > 0:
                     if gpio_width_int - pin_counter  > 32:
                         split_signal_dict.append([f"{gpio_name}_{pin_counter}_{pin_counter+31}", 32, pin_counter, pin_counter+31])
                         pin_counter += 32
-                    elif gpio_width_int - pin_counter < 32:
+                    elif gpio_width_int - pin_counter <= 32:
                         split_signal_dict.append([f"{gpio_name}_{pin_counter}_{gpio_width_int-1}", gpio_width_int-pin_counter, pin_counter, gpio_width_int-1])
-            
+                        pin_counter += gpio_width_int - pin_counter
                 # From here is different.
                 # 1) Make n separate ALL INPUT GPIO.
                 # 2) Add a Slice IP for each of the GPIO signals created.
@@ -687,12 +687,13 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 # Precurser: Make an array similar to all_ports that will store config.
                 split_signal_dict = []
                 pin_counter = 0
-                while gpio_width_int - pin_counter >= 0:
+                while gpio_width_int - pin_counter > 0:
                     if gpio_width_int - pin_counter  > 32:
                         split_signal_dict.append([f"{gpio_name}_{pin_counter}_{pin_counter+31}", 32])
                         pin_counter += 32
-                    elif gpio_width_int - pin_counter < 32:
+                    elif gpio_width_int - pin_counter <= 32:
                         split_signal_dict.append([f"{gpio_name}_{pin_counter}_{gpio_width_int-1}", gpio_width_int-pin_counter])
+                        pin_counter += gpio_width_int - pin_counter
 
                 # Now we have formed a split signal map, we can follow the steps.
 

--- a/application/tcl_generator.py
+++ b/application/tcl_generator.py
@@ -722,11 +722,11 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 break
 
         # (7) Add the AXI Interconnect to the IP Block Design
-        file_contents += f"\nadd_axi_interconnect 1 {len(all_ports)}"
+        file_contents += f"\nadd_axi_interconnect 1 {len(created_signals)}"
 
         # Connect each GPIO to the Interconnect
-        for x in range(len(all_ports)):
-            file_contents += f"\nconnect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M{x:02d}_AXI] [get_bd_intf_pins {all_ports[x][0]}/S_AXI]"
+        for x in range(len(created_signals)):
+            file_contents += f"\nconnect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M{x:02d}_AXI] [get_bd_intf_pins {created_signals[x]}/S_AXI]"
             
 
         # (8) Add "Processor System Reset" IP
@@ -739,7 +739,7 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
         # file_contents += "\nrun_bd_auto_connect"
         file_contents += "\nrun_bd_automation_rule_processor"
         file_contents += "\nrun_bd_automation_rule_interconnect"
-        for io in all_ports:
+        for io in created_signals:
             file_contents += f"\nrun_bd_automation_rule_io {io[0]}/s_axi_aclk" 
         
 

--- a/application/tcl_generator.py
+++ b/application/tcl_generator.py
@@ -619,91 +619,12 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 print(gpio_type)
 
 
-            if gpio_mode == "out":
+            if gpio_mode == "out" and int(gpio_width) <= 32:
                 print(gpio_name) 
-                ####### Detected the Suffix of the Signal and Connecting I/O
-                # proc make_external_connection {component bd_pin external_pin_name}
-                
-                #run_external_connection(#)
-                
-                ######################### Auto Connect based on Suffix #########################
-                ###### This commented codeblock auto connects based on suffix, for example _led. 
-                ###### On 17/02/24 decided that it is better approach to let user decide in SoC builder as HDLGen is too early to care about specific I/O ports.
-
-                # First: 
-                # io_suffix = ["_led", "_led0", "_led1", "_led2", "_led3", "_led01", "_led02", "_led03", "_led12", "_led13", "_led23", "_led3"]
-                # suffix_detected = None
-                # for suff in io_suffix:
-                #     if gpio_name.endswith(suff):
-                #         suffix_detected = suff
-                # if suffix_detected:
-                #     if suffix_detected == io_suffix[0]: #   _led
-                #         # Automatic assignment
-                #         # io_dictionary = {
-                #         #     'led0': None,
-                #         #     'led1': None,
-                #         #     'led2': None,
-                #         #     'led3': None
-                #         # }
-                        
-                #         # Count the number of LED IO available.
-                #         count = sum(value == None for value in io_dictionary.values())
-                #         if count > gpio_width:
-                #             print(f"The GPIO signal is greater the # of LED pins available - Assigning {count} LSBs.")
-                        
-                #         external_connection = gpio_name + "_ext"
-                #         file_contents += f"\nmake_external_connection {module_source}_0 {gpio_name} {external_connection}"
-
-                #         connections_made = 0
-                #         for key in io_dictionary.keys():    # Cycle thru each key in io dictionary
-                #             if io_dictionary[key] == None:  # If the I/O is available:
-                #                 board_gpio = key
-                #                 external_connection_pin = external_connection + "[" + str(connections_made) + "]"
-                #                 io_dictionary[key] = external_connection_pin               # Assign the connection (eg: "led0": "count_ext[0]")
-                #                 xdc_contents += add_line_to_xdc(board_gpio, external_connection_pin)        # Create connection in Physical Contraints File
-                #                 connections_made += 1
-
-                #         print("Summary of Connections:")
-                #         print(io_dictionary)
-
-                #         # Opportunity: Can use the following "highest consecutive sequence" code to try fit a signal consecutively instead.
-                #         # for value in io_dictionary.values():
-                #         #     if value == value_to_check:
-                #         #         current_sequence += 1
-                #         #         max_sequence = max(max_sequence, current_sequence)
-                #         #     else:
-                #         #         current_sequence = 0
- 
-                #         pass
-                #     elif suffix_detected == io_suffix[1]: # _led0
-                #         pass
-                #     elif suffix_detected == io_suffix[2]: # _led1
-                #         pass
-                #     elif suffix_detected == io_suffix[3]: # _led2
-                #         pass
-                #     elif suffix_detected == io_suffix[4]: # _led01
-                #         pass
-                #     elif suffix_detected == io_suffix[5]: # _led01
-                #         pass
-                #     elif suffix_detected == io_suffix[6]: # _led02
-                #         pass 
-                #     elif suffix_detected == io_suffix[7]: # _led03
-                #         pass
-                #     elif suffix_detected == io_suffix[8]: # _led12
-                #         pass
-                #     elif suffix_detected == io_suffix[9]: # _led13
-                #         pass
-                #     elif suffix_detected == io_suffix[10]: # _led23
-                #         pass
-                #     elif suffix_detected == io_suffix[11]: # _led3
-                #         pass
-                #     else:
-                #         print("ERROR: IO Out of range.")
-
                 file_contents += f"\nadd_axi_gpio_all_input {gpio_name} {gpio_width}"
                 # If the GPIO is added correctly, connect it to the User I/O
                 file_contents += f"\nconnect_gpio_all_input_to_module_port {gpio_name} {module_source}_0"
-            elif gpio_mode == "in":
+            elif gpio_mode == "in" and int(gpio_width) <= 32:
                 file_contents += f"\nadd_axi_gpio_all_output {gpio_name} {gpio_width}"
                 # If the GPIO is added correctly, connect it to the User I/O
                 file_contents += f"\nconnect_gpio_all_output_to_module_port {gpio_name} {module_source}_0"

--- a/application/tcl_generator.py
+++ b/application/tcl_generator.py
@@ -665,10 +665,10 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                     file_contents += f"\nadd_slice_ip {sub_sig[0]}_slice {gpio_width} {sub_sig[3]} {sub_sig[2]} {sub_sig[1]}"
                 # 3) Connect Component to Slices
                 for sub_sig in split_signal_dict:
-                    file_contents += f"connect_bd_net [get_bd_pins {module_source}_0/{gpio_name}] [get_bd_pins {sub_sig[0]}_slice/Din]"
+                    file_contents += f"\nconnect_bd_net [get_bd_pins {module_source}_0/{gpio_name}] [get_bd_pins {sub_sig[0]}_slice/Din]"
                 # 4) Connect the Slices to GPIO
                 for sub_sig in split_signal_dict:
-                    file_contents += f"connect_bd_net [get_bd_pins {sub_sig[0]}/gpio_io_i] [get_bd_pins {sub_sig[0]}_slice/Dout]"
+                    file_contents += f"\nconnect_bd_net [get_bd_pins {sub_sig[0]}/gpio_io_i] [get_bd_pins {sub_sig[0]}_slice/Dout]"
                 # 5) Add signals to created_signals dictionary - Required by interconnect steps later.
                 for sub_sig in split_signal_dict:
                     created_signals.append(sub_sig[0])
@@ -741,7 +741,7 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
         file_contents += "\nrun_bd_automation_rule_processor"
         file_contents += "\nrun_bd_automation_rule_interconnect"
         for io in created_signals:
-            file_contents += f"\nrun_bd_automation_rule_io {io[0]}/s_axi_aclk" 
+            file_contents += f"\nrun_bd_automation_rule_io {io}/s_axi_aclk" 
         
 
         # Run block automation tool

--- a/application/tcl_generator.py
+++ b/application/tcl_generator.py
@@ -643,10 +643,10 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 pin_counter = 0
                 while gpio_width_int - pin_counter > 0:
                     if gpio_width_int - pin_counter  > 32:
-                        split_signal_dict.append([f"{gpio_name}_{pin_counter}_{pin_counter+31}", 32, pin_counter, pin_counter+31])
+                        split_signal_dict.append([f"{gpio_name}_{pin_counter+31}_{pin_counter}", 32, pin_counter, pin_counter+31])
                         pin_counter += 32
                     elif gpio_width_int - pin_counter <= 32:
-                        split_signal_dict.append([f"{gpio_name}_{pin_counter}_{gpio_width_int-1}", gpio_width_int-pin_counter, pin_counter, gpio_width_int-1])
+                        split_signal_dict.append([f"{gpio_name}_{gpio_width_int-1}_{pin_counter}", gpio_width_int-pin_counter, pin_counter, gpio_width_int-1])
                         pin_counter += gpio_width_int - pin_counter
                 # From here is different.
                 # 1) Make n separate ALL INPUT GPIO.
@@ -689,10 +689,10 @@ def generate_tcl(path_to_hdlgen_project, regenerate_bd=True, start_gui=True, kee
                 pin_counter = 0
                 while gpio_width_int - pin_counter > 0:
                     if gpio_width_int - pin_counter  > 32:
-                        split_signal_dict.append([f"{gpio_name}_{pin_counter}_{pin_counter+31}", 32])
+                        split_signal_dict.append([f"{gpio_name}_{pin_counter+31}_{pin_counter}", 32])
                         pin_counter += 32
                     elif gpio_width_int - pin_counter <= 32:
-                        split_signal_dict.append([f"{gpio_name}_{pin_counter}_{gpio_width_int-1}", gpio_width_int-pin_counter])
+                        split_signal_dict.append([f"{gpio_name}_{gpio_width_int-1}_{pin_counter}", gpio_width_int-pin_counter])
                         pin_counter += gpio_width_int - pin_counter
 
                 # Now we have formed a split signal map, we can follow the steps.

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -77,22 +77,20 @@ add_axi_gpio_all_input dOut_0_31    ; # Make two separate GPIO
 add_axi_gpio_all_input dOut_32_63   ; # Make two separate GPIO
 
 # We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
-add_concat_ip 2 dOut_concat         ; # Create the new CONCAT IP
+# We need 1 SLICE per GPIO
 
-connect_bd_net [get_bd_pins dOut_0_31/gpio_io_i] [get_bd_pins dOut_concat/In0]      ; # Connect GPIO to CONCAT
-connect_bd_net [get_bd_pins dOut_32_63/gpio_io_i] [get_bd_pins dOut_concat/In1]     ; # Connect CONCAT to GPIO
-
-connect_bd_net [get_bd_pins dOut_concat/dout] [get_bd_pins FIFO4x64Top_0/dIn]       ; # Connect Output of component to input of CONCAT
-
+# proc add_slice_ip {name dIn_width dIn_from dIn_downto dout_width} {
+add_slice_ip dOut_0_31_slice 64 31 0 32
+add_slice_ip dOut_32_63_slice 64 63 32 32
 
 
+connect_bd_net [get_bd_pins dOut_0_31/gpio_io_i] [get_bd_pins dOut_0_31_slice/Dout]      ; # Connecting GPIO to slices
+connect_bd_net [get_bd_pins dOut_32_63/gpio_io_i] [get_bd_pins dOut_32_63_slice/Dout]    ; # Connecting higher slice to GPIO
 
+connect_bd_net [get_bd_pins FIFO4x64Top_0/dOut] [get_bd_pins dOut_0_31_slice/Din]       ; # Connect Output of component to input of CONCAT
+connect_bd_net [get_bd_pins FIFO4x64Top_0/dOut] [get_bd_pins dOut_32_63_slice/Din]       ; # Connect Output of component to input of CONCAT
 
-
-
-
-
-
+# This section above is now valid as far as I know.
 
 
 

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -94,15 +94,19 @@ connect_bd_net [get_bd_pins FIFO4x64Top_0/dOut] [get_bd_pins dOut_32_63_slice/Di
 
 
 
-add_axi_interconnect 1 8
+add_axi_interconnect 1 10   ; # Needed to add 2 to facilitate new GPIO ports.
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M00_AXI] [get_bd_intf_pins clk/S_AXI]
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M01_AXI] [get_bd_intf_pins rst/S_AXI]
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M02_AXI] [get_bd_intf_pins rd/S_AXI]
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M03_AXI] [get_bd_intf_pins wr/S_AXI]
-connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn/S_AXI]
+# connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn/S_AXI] - This signal no longer exists. It has been split.
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn_0_31/S_AXI] ; # Connected GPIO port 0_31
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M09_AXI] [get_bd_intf_pins dIn_32_63/S_AXI] ; # Connected GPIO port 32_63
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M05_AXI] [get_bd_intf_pins full/S_AXI]
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M06_AXI] [get_bd_intf_pins empty/S_AXI]
-connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut/S_AXI]
+# connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut/S_AXI] - This signal no longer exists. It has been split.
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut_0_31/S_AXI] ; # Connected GPIO port 0_31
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M10_AXI] [get_bd_intf_pins dOut_32_63/S_AXI] ; #  Connected GPIO port 32_63
 add_system_reset_ip
 connect_bd_intf_net [get_bd_intf_pins processing_system7_0/M_AXI_GP0] -boundary_type upper [get_bd_intf_pins axi_interconnect_0/S00_AXI]
 run_bd_automation_rule_processor
@@ -111,10 +115,14 @@ run_bd_automation_rule_io clk/s_axi_aclk
 run_bd_automation_rule_io rst/s_axi_aclk
 run_bd_automation_rule_io rd/s_axi_aclk
 run_bd_automation_rule_io wr/s_axi_aclk
-run_bd_automation_rule_io dIn/s_axi_aclk
+# run_bd_automation_rule_io dIn/s_axi_aclk
+run_bd_automation_rule_io dIn_0_31/s_axi_aclk
+run_bd_automation_rule_io dIn_32_63/s_axi_aclk
 run_bd_automation_rule_io full/s_axi_aclk
 run_bd_automation_rule_io empty/s_axi_aclk
-run_bd_automation_rule_io dOut/s_axi_aclk
+# run_bd_automation_rule_io dOut/s_axi_aclk
+run_bd_automation_rule_io dOut_0_31/s_axi_aclk
+run_bd_automation_rule_io dOut_32_63/s_axi_aclk
 run_bd_block_automation
 run_addr_editor_auto_assign
 validate_bd

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -1,0 +1,105 @@
+source C:/repo/PYNQ-SoC-Builder/application/generate_procs.tcl
+start_gui
+open_project C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.xpr
+set_property board_part tul.com.tw:pynq-z2:part0:1.0 [current_project]
+set constraint_name "constrs_1"
+set xdc_exists [file exists C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/constrs_1/imports/generated/physical_constr.xdc]
+if {$xdc_exists} {
+    export_ip_user_files -of_objects  [get_files {{C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/constrs_1/imports/generated/physical_constr.xdc}}] -no_script -reset -force -quiet
+    remove_files  -fileset constrs_1 {{C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/constrs_1/imports/generated/physical_constr.xdc}}
+    file delete -force {C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/constrs_1/imports/generated/physical_constr.xdc}
+}
+add_files -fileset constrs_1 -norecurse {C:/repo/PYNQ-SoC-Builder/generated/physical_constr.xdc}
+import_files -force -fileset constrs_1 {C:/repo/PYNQ-SoC-Builder/generated/physical_constr.xdc}
+delete_file C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd/FIFO4x64Top_bd.bd
+create_bd_file FIFO4x64Top_bd
+add_processing_unit
+set_property source_mgmt_mode All [current_project]
+add_module FIFO4x64Top FIFO4x64Top_0
+update_compile_order -fileset sources_1
+update_compile_order -fileset sim_1
+add_axi_gpio_all_output clk 1
+connect_gpio_all_output_to_module_port clk FIFO4x64Top_0
+add_axi_gpio_all_output rst 1
+connect_gpio_all_output_to_module_port rst FIFO4x64Top_0
+add_axi_gpio_all_output rd 1
+connect_gpio_all_output_to_module_port rd FIFO4x64Top_0
+add_axi_gpio_all_output wr 1
+connect_gpio_all_output_to_module_port wr FIFO4x64Top_0
+
+# add_axi_gpio_all_output dIn 64                                          ; # Problem Line
+# connect_gpio_all_output_to_module_port dIn FIFO4x64Top_0                ; # Problem Line
+add_axi_gpio_all_output dIn_0_31
+add_axi_gpio_all_output dIn_32_63
+
+# We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
+add_concat_ip 2 dIn_concat
+
+connect_bd_net [get_bd_pins dIn_0_31/gpio_io_o] [get_bd_pins dIn_concat/In0]
+connect_bd_net [get_bd_pins dIn_32_63/gpio_io_o] [get_bd_pins dIn_concat/In1]
+
+# set_property -dict [list CONFIG.NUM_PORTS {3}] [get_bd_cells xlconcat_0] ; # default is 2 ports and auto mode, we are going to attempt to use auto mode.
+# Port 0 being LSB compared to port 1,2,3,4 etc.
+
+# connect_bd_net [get_bd_pins Untitled_0/count] [get_bd_pins xlconcat_0/In0]
+# connect_bd_net [get_bd_pins Untitled_0/TC] [get_bd_pins xlconcat_0/In1]
+# connect_bd_net [get_bd_pins Untitled_0/ceo] [get_bd_pins xlconcat_0/In2]
+
+add_axi_gpio_all_input full 1
+connect_gpio_all_input_to_module_port full FIFO4x64Top_0
+add_axi_gpio_all_input empty 1
+connect_gpio_all_input_to_module_port empty FIFO4x64Top_0
+
+# add_axi_gpio_all_input dOut 64                                          ; # Problem Line
+# connect_gpio_all_input_to_module_port dOut FIFO4x64Top_0                ; # Problem Line
+add_axi_gpio_all_input dOut_0_31
+add_axi_gpio_all_input dOut_32_63
+
+# We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
+add_concat_ip 2 dIn_concat
+
+connect_bd_net [get_bd_pins dOut_0_31/gpio_io_i] [get_bd_pins dIn_concat/In0]
+connect_bd_net [get_bd_pins dIn_32_63/gpio_io_i] [get_bd_pins dIn_concat/In1]
+
+
+
+
+
+add_axi_interconnect 1 8
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M00_AXI] [get_bd_intf_pins clk/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M01_AXI] [get_bd_intf_pins rst/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M02_AXI] [get_bd_intf_pins rd/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M03_AXI] [get_bd_intf_pins wr/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M05_AXI] [get_bd_intf_pins full/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M06_AXI] [get_bd_intf_pins empty/S_AXI]
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut/S_AXI]
+add_system_reset_ip
+connect_bd_intf_net [get_bd_intf_pins processing_system7_0/M_AXI_GP0] -boundary_type upper [get_bd_intf_pins axi_interconnect_0/S00_AXI]
+run_bd_automation_rule_processor
+run_bd_automation_rule_interconnect
+run_bd_automation_rule_io clk/s_axi_aclk
+run_bd_automation_rule_io rst/s_axi_aclk
+run_bd_automation_rule_io rd/s_axi_aclk
+run_bd_automation_rule_io wr/s_axi_aclk
+run_bd_automation_rule_io dIn/s_axi_aclk
+run_bd_automation_rule_io full/s_axi_aclk
+run_bd_automation_rule_io empty/s_axi_aclk
+run_bd_automation_rule_io dOut/s_axi_aclk
+run_bd_block_automation
+run_addr_editor_auto_assign
+validate_bd
+set wrapper_exists [file exists C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd_wrapper.vhd]
+if {$wrapper_exists} {
+    export_ip_user_files -of_objects  [get_files C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd_wrapper.vhd] -no_script -reset -force -quiet
+    remove_files  C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd_wrapper.vhd
+    file delete -force C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd_wrapper.vhd
+    update_compile_order -fileset sources_1
+} else {
+    create_hdl_wrapper C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd FIFO4x64Top_bd
+    set_wrapper_top FIFO4x64Top_bd_wrapper
+}
+generate_bitstream
+open_bd_design C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top.srcs/sources_1/bd/FIFO4x64Top_bd/FIFO4x64Top_bd.bd
+export_bd C:/repo/HDLGen-ChatGPT-Latest/User_Projects/ToLuke/FIFOs/FIFO4x64Top/VHDL/AMDprj/FIFO4x64Top_bd.tcl
+wait_on_run impl_1

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -29,37 +29,68 @@ connect_gpio_all_output_to_module_port wr FIFO4x64Top_0
 
 # add_axi_gpio_all_output dIn 64                                          ; # Problem Line
 # connect_gpio_all_output_to_module_port dIn FIFO4x64Top_0                ; # Problem Line
-add_axi_gpio_all_output dIn_0_31
-add_axi_gpio_all_output dIn_32_63
+
+
+
+##
+## TO CONNECT AN INPUT, WE CONCAT n SIGNALS TOGETHER
+##
+
+
+add_axi_gpio_all_output dIn_0_31    ; # Make two separate GPIO
+add_axi_gpio_all_output dIn_32_63   ; # Make two separate GPIO
 
 # We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
-add_concat_ip 2 dIn_concat
+add_concat_ip dIn_concat 2 ; # Create concat component
 
-connect_bd_net [get_bd_pins dIn_0_31/gpio_io_o] [get_bd_pins dIn_concat/In0]
-connect_bd_net [get_bd_pins dIn_32_63/gpio_io_o] [get_bd_pins dIn_concat/In1]
 
-# set_property -dict [list CONFIG.NUM_PORTS {3}] [get_bd_cells xlconcat_0] ; # default is 2 ports and auto mode, we are going to attempt to use auto mode.
-# Port 0 being LSB compared to port 1,2,3,4 etc.
+# Currently dealing with dIn (an ALL OUTPUT signal)
+connect_bd_net [get_bd_pins dIn_0_31/gpio_io_o] [get_bd_pins dIn_concat/In0]        ; # Connect GPIO to CONCAT
+connect_bd_net [get_bd_pins dIn_32_63/gpio_io_o] [get_bd_pins dIn_concat/In1]       ; # Connect GPIO to CONCAT
 
-# connect_bd_net [get_bd_pins Untitled_0/count] [get_bd_pins xlconcat_0/In0]
-# connect_bd_net [get_bd_pins Untitled_0/TC] [get_bd_pins xlconcat_0/In1]
-# connect_bd_net [get_bd_pins Untitled_0/ceo] [get_bd_pins xlconcat_0/In2]
+connect_bd_net [get_bd_pins dIn_concat/dout] [get_bd_pins FIFO4x64Top_0/dIn]        ; # Connect CONCAT to Input of component
 
+
+##### This is resonably fine above now.
+
+
+
+# Other signals that are not problematic
 add_axi_gpio_all_input full 1
 connect_gpio_all_input_to_module_port full FIFO4x64Top_0
 add_axi_gpio_all_input empty 1
 connect_gpio_all_input_to_module_port empty FIFO4x64Top_0
+# End
+
+
+##
+## TO CONNECT AN OUTPUT, WE SLICE n SIGNALS APPART INTO SEPARATE GPIO
+##
+
+
+# This is all mistaken, we need to SPLIT then in the reverse. 
 
 # add_axi_gpio_all_input dOut 64                                          ; # Problem Line
 # connect_gpio_all_input_to_module_port dOut FIFO4x64Top_0                ; # Problem Line
-add_axi_gpio_all_input dOut_0_31
-add_axi_gpio_all_input dOut_32_63
+
+add_axi_gpio_all_input dOut_0_31    ; # Make two separate GPIO
+add_axi_gpio_all_input dOut_32_63   ; # Make two separate GPIO
 
 # We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
-add_concat_ip 2 dIn_concat
+add_concat_ip 2 dOut_concat         ; # Create the new CONCAT IP
 
-connect_bd_net [get_bd_pins dOut_0_31/gpio_io_i] [get_bd_pins dIn_concat/In0]
-connect_bd_net [get_bd_pins dIn_32_63/gpio_io_i] [get_bd_pins dIn_concat/In1]
+connect_bd_net [get_bd_pins dOut_0_31/gpio_io_i] [get_bd_pins dOut_concat/In0]      ; # Connect GPIO to CONCAT
+connect_bd_net [get_bd_pins dOut_32_63/gpio_io_i] [get_bd_pins dOut_concat/In1]     ; # Connect CONCAT to GPIO
+
+connect_bd_net [get_bd_pins dOut_concat/dout] [get_bd_pins FIFO4x64Top_0/dIn]       ; # Connect Output of component to input of CONCAT
+
+
+
+
+
+
+
+
 
 
 

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -101,12 +101,12 @@ connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M0
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M03_AXI] [get_bd_intf_pins wr/S_AXI]
 # connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn/S_AXI] - This signal no longer exists. It has been split.
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M04_AXI] [get_bd_intf_pins dIn_0_31/S_AXI] ; # Connected GPIO port 0_31
-connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M09_AXI] [get_bd_intf_pins dIn_32_63/S_AXI] ; # Connected GPIO port 32_63
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M08_AXI] [get_bd_intf_pins dIn_32_63/S_AXI] ; # Connected GPIO port 32_63
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M05_AXI] [get_bd_intf_pins full/S_AXI]
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M06_AXI] [get_bd_intf_pins empty/S_AXI]
 # connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut/S_AXI] - This signal no longer exists. It has been split.
 connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M07_AXI] [get_bd_intf_pins dOut_0_31/S_AXI] ; # Connected GPIO port 0_31
-connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M10_AXI] [get_bd_intf_pins dOut_32_63/S_AXI] ; #  Connected GPIO port 32_63
+connect_bd_intf_net -boundary_type upper [get_bd_intf_pins axi_interconnect_0/M09_AXI] [get_bd_intf_pins dOut_32_63/S_AXI] ; #  Connected GPIO port 32_63
 add_system_reset_ip
 connect_bd_intf_net [get_bd_intf_pins processing_system7_0/M_AXI_GP0] -boundary_type upper [get_bd_intf_pins axi_interconnect_0/S00_AXI]
 run_bd_automation_rule_processor

--- a/generated/generate_script_modified.tcl
+++ b/generated/generate_script_modified.tcl
@@ -37,8 +37,8 @@ connect_gpio_all_output_to_module_port wr FIFO4x64Top_0
 ##
 
 
-add_axi_gpio_all_output dIn_0_31    ; # Make two separate GPIO
-add_axi_gpio_all_output dIn_32_63   ; # Make two separate GPIO
+add_axi_gpio_all_output dIn_0_31 32  ; # Make two separate GPIO
+add_axi_gpio_all_output dIn_32_63 32 ; # Make two separate GPIO
 
 # We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
 add_concat_ip dIn_concat 2 ; # Create concat component
@@ -73,8 +73,8 @@ connect_gpio_all_input_to_module_port empty FIFO4x64Top_0
 # add_axi_gpio_all_input dOut 64                                          ; # Problem Line
 # connect_gpio_all_input_to_module_port dOut FIFO4x64Top_0                ; # Problem Line
 
-add_axi_gpio_all_input dOut_0_31    ; # Make two separate GPIO
-add_axi_gpio_all_input dOut_32_63   ; # Make two separate GPIO
+add_axi_gpio_all_input dOut_0_31 32 ;  # Make two separate GPIO
+add_axi_gpio_all_input dOut_32_63 32 ; # Make two separate GPIO
 
 # We can't "connect_gpio_all_output_to_module_port" directly, we need a concat IP.
 # We need 1 SLICE per GPIO


### PR DESCRIPTION
In this pull request:
- New procedures added to generate_procs.tcl file (add_slice_ip, add_concat_ip)
- Support for >32 bit buses, there is an assumption that only HEX will be used for these larger signals.
- Interconnect and connection automation actions updated to support added GPIO
- JNB now has summary of each test case in each test cell
- Hex and binary values are padded